### PR TITLE
Springboot 3.4.13 -> 3.5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Collection returned on endpoint: /api/logs/withCollection, size: 2, status: 200
 
 ### Changelog:
 
+##### 27.01.2026
+
+* Springboot 3.4.4 -> 3.5.10
+
 ##### 30.10.2025
 
 * Added support for logging around requests

--- a/chassis-bom/pom.xml
+++ b/chassis-bom/pom.xml
@@ -13,8 +13,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <springboot.version>3.4.13</springboot.version>
-        <spring-cloud-dependencies.version>2024.0.3</spring-cloud-dependencies.version>
+        <springboot.version>3.5.10</springboot.version>
+        <spring-cloud-dependencies.version>2025.0.1</spring-cloud-dependencies.version>
 
         <sonar.organization>milczekt1</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/chassis-parent/pom.xml
+++ b/chassis-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.13</version>
+        <version>3.5.10</version>
         <relativePath/>
     </parent>
 
@@ -20,8 +20,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <springboot.version>3.4.13</springboot.version>
-        <spring-cloud-dependencies.version>2024.0.3</spring-cloud-dependencies.version>
+        <springboot.version>3.5.10</springboot.version>
+        <spring-cloud-dependencies.version>2025.0.1</spring-cloud-dependencies.version>
 
         <!--Properties to override        -->
         <jacoco.classes.maxMissed>0</jacoco.classes.maxMissed>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <springboot.version>3.4.13</springboot.version>
-        <spring-cloud-dependencies.version>2024.0.3</spring-cloud-dependencies.version>
+        <springboot.version>3.5.10</springboot.version>
+        <spring-cloud-dependencies.version>2025.0.1</spring-cloud-dependencies.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.organization>milczekt1</sonar.organization>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Spring Boot from 3.4.13 to 3.5.10
  * Updated Spring Cloud dependencies from 2024.0.3 to 2025.0.1

* **Documentation**
  * Added changelog entry recording the dependency updates (27.01.2026)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->