### PR TITLE
Springboot 4.0.6 alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,17 @@ Collection returned on endpoint: /api/logs/withCollection, size: 2, status: 200
 
 ### Changelog:
 
+##### 03.06.2026
+
+* Upgraded Spring Boot 4.0.3 -> 4.0.6 (root pom, `chassis-bom`, `chassis-parent` property and
+  `spring-boot-starter-parent`); kept Spring Cloud 2025.1.1 (latest patch on the SB-4.0-compatible line).
+* Aligned versions to the Spring Boot 4.0.6 BOM by removing redundant `chassis-bom` pins it already manages at the
+  same version (Lombok, junit:junit, assertj-core, testcontainers-mongodb, h2) and dropping the local `lombok.version`
+  property in `chassis-parent`.
+* JUnit now follows the SB-managed junit-bom 6.0.3 (removed the `chassis-tools-test` junit-bom 5.14.4 override) and
+  archunit-junit5 is unified at 1.4.1 (removed the divergent 1.4.0 pin). Kept intentionally-newer pins (mockito-core
+  5.21.0, maven-surefire/failsafe 3.5.6, git-commit-id 9.2.0) to avoid downgrades.
+
 ##### 02.06.2026
 
 * Migrated to Java 25 (Spring Boot 4.0.3, Spring Cloud 2025.1.1). CI runners and the `Dockerfile` base image

--- a/chassis-bom/pom.xml
+++ b/chassis-bom/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <springboot.version>4.0.3</springboot.version>
+        <springboot.version>4.0.6</springboot.version>
         <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version>
 
         <sonar.organization>milczekt1</sonar.organization>
@@ -67,29 +67,12 @@
 
             <!-- OTHER LIBRARIES-->
             <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>1.18.46</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>33.6.0-jre</version>
             </dependency>
 
             <!-- TEST LIBRARIES-->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>3.27.7</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
@@ -106,17 +89,6 @@
                 <groupId>de.flapdoodle.embed</groupId>
                 <artifactId>de.flapdoodle.embed.mongo.spring30x</artifactId>
                 <version>4.22.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-mongodb</artifactId>
-                <version>2.0.5</version>
-            </dependency>
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>2.4.240</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/chassis-parent/pom.xml
+++ b/chassis-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 
@@ -20,9 +20,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <springboot.version>4.0.3</springboot.version>
+        <springboot.version>4.0.6</springboot.version>
         <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version>
-        <lombok.version>1.18.46</lombok.version>
 
         <!--Properties to override        -->
         <jacoco.classes.maxMissed>0</jacoco.classes.maxMissed>

--- a/chassis-tools-test/pom.xml
+++ b/chassis-tools-test/pom.xml
@@ -37,13 +37,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>5.14.4</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -86,7 +79,6 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
-            <version>1.4.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <springboot.version>4.0.3</springboot.version>
+        <springboot.version>4.0.6</springboot.version>
         <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Spring Boot to version 4.0.6
  * Removed redundant dependency pins and cleaned up unnecessary version properties
  * Unified test framework dependency versions including JUnit5 and ArchUnit alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->