### PR TITLE
Updated GitHub Actions versions in the CI workflows: `actions/checkout` v4 -> v6, `actions/setup-java` v4 -> v5,   and `actions/cache` (restore/save) v4 -> v5.

### DIFF
--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -21,17 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Restore Maven Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
           key: ${{ env.CACHE_KEY }}
       - name: Set up JDK for dependency download
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin
@@ -65,7 +65,7 @@ jobs:
           fi
       - name: Upload Maven Cache
         if: ${{ steps.stale-cache-check.outputs.cache-outdated }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
           key: ${{ env.CACHE_KEY }}
@@ -75,14 +75,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore Maven cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
           key: ${{ env.CACHE_KEY }}
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin
@@ -96,14 +96,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore Maven cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
           key: ${{ env.CACHE_KEY }}
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -19,9 +19,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Collection returned on endpoint: /api/logs/withCollection, size: 2, status: 200
 
 ##### 03.06.2026
 
+* Updated GitHub Actions versions in the CI workflows: `actions/checkout` v4 -> v6, `actions/setup-java` v4 -> v5,
+  and `actions/cache` (restore/save) v4 -> v5.
 * Added `spring-boot-configuration-processor` to the `maven-compiler-plugin` `annotationProcessorPaths` in both the
   root `chassis` pom and `chassis-parent`. Once `annotationProcessorPaths` is declared, Maven discovers processors
   only from that list, so the Spring Boot processor was being suppressed and no `spring-configuration-metadata.json`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions across CI/CD workflows for improved compatibility and performance.

* **Documentation**
  * Updated changelog to reflect dependency version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->